### PR TITLE
CAAS: Add flagged-message logging, tracked targets and invite-lists; expose CAAS APIs; remove MEMSHADOW from default stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Core SPECTRA web service
+SPECTRA_BOOTSTRAP_SECRET=
+SPECTRA_SESSION_SECRET=replace-with-strong-secret
+SPECTRA_JWT_SECRET=replace-with-strong-secret
+SPECTRA_WEBAUTHN_ORIGIN=http://localhost:5000
+SPECTRA_WEBAUTHN_RP_ID=localhost
+SPECTRA_WEBAUTHN_RP_NAME=SPECTRA
+
+# Optional integration endpoints
+# Leave blank to run without sidecars. Set URL to reconnect later.
+SPECTRA_MEMSHADOW_URL=
+
+# Vector search key
+QDRANT_API_KEY=replace-with-strong-api-key
+
+# Add new provider keys below as needed
+# OPENAI_API_KEY=
+# ANTHROPIC_API_KEY=
+# MISTRAL_API_KEY=

--- a/Caddyfile
+++ b/Caddyfile
@@ -14,16 +14,6 @@
         header_up X-Forwarded-Proto {scheme}
     }
 
-    # Reverse proxy to MEMSHADOW sidecar
-    handle_path /memshadow* {
-        reverse_proxy memshadow:18080 {
-            header_up Host {host}
-            header_up X-Real-IP {remote_host}
-            header_up X-Forwarded-For {remote_host}
-            header_up X-Forwarded-Proto {scheme}
-        }
-    }
-
     # Logging
     log {
         output file /var/log/caddy/access.log

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ SPECTRA is a forensic-grade intelligence framework for Telegram network discover
 - 💳 **Wallet-Watch (DIRECTEYE Ready)**: Forensic extraction of BTC, XMR, and TRX/ETH addresses with built-in hooks for [DIRECTEYE](https://github.com/SWORDIntel/DIRECTEYE) blockchain attribution.
 - 🚀 **One-Command Deployment**: Production-ready Docker orchestration with automated SSL via **Caddy**.
 - 🛡️ **OPSEC Core**: Multi-account/API rotation and proxy support for anti-detection and persistent collection.
-- 🧠 **MEMSHADOW Sidecar**: Advanced 4096-dimensional semantic memory persistence and cross-LLM context preservation for deep threat analysis.
+- 🧠 **MEMSHADOW Integration Ready**: Sidecar is optional and can be reconnected via `SPECTRA_MEMSHADOW_URL` without changing route contracts.
 
 ## ⚡ Quick Start (Docker)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       SPECTRA_MEDIA_DIR: "/app/media"
       SPECTRA_LOG_DIR: "/app/logs"
       SPECTRA_CHECKPOINT_DIR: "/app/checkpoints"
+      SPECTRA_MEMSHADOW_URL: "${SPECTRA_MEMSHADOW_URL:-}"
 
     ports:
       - "5000:5000"
@@ -75,88 +76,6 @@ services:
         limits:
           memory: 512M
 
-  # ============================================================================
-  # MEMSHADOW SIDECAR - Advanced Memory Persistence & Semantic Analysis
-  # ============================================================================
-
-  memshadow-db:
-    image: postgres:15-alpine
-    container_name: memshadow-postgres
-    restart: unless-stopped
-    environment:
-      POSTGRES_USER: memshadow
-      POSTGRES_PASSWORD: ${MEMSHADOW_POSTGRES_PASSWORD:-1786}
-      POSTGRES_DB: memshadow
-    volumes:
-      - memshadow-postgres-data:/var/lib/postgresql/data
-    networks:
-      - spectra-network
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U memshadow"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
-  memshadow-cache:
-    image: redis:7-alpine
-    container_name: memshadow-redis
-    restart: unless-stopped
-    command: redis-server --requirepass ${MEMSHADOW_REDIS_PASSWORD:-1786}
-    volumes:
-      - memshadow-redis-data:/data
-    networks:
-      - spectra-network
-    healthcheck:
-      test: ["CMD", "redis-cli", "-a", "${MEMSHADOW_REDIS_PASSWORD:-1786}", "ping"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
-  memshadow-vector:
-    image: chromadb/chroma:latest
-    container_name: memshadow-chromadb
-    restart: unless-stopped
-    environment:
-      CHROMA_SERVER_AUTH_PROVIDER: "chromadb.auth.token.TokenAuthServerProvider"
-      CHROMA_SERVER_AUTH_CREDENTIALS: ${MEMSHADOW_CHROMA_TOKEN:-1786}
-    volumes:
-      - memshadow-chroma-data:/chroma/chroma
-    networks:
-      - spectra-network
-
-  memshadow:
-    build:
-      context: ./src/MEMSHADOW
-      dockerfile: Dockerfile
-    container_name: memshadow-app
-    restart: unless-stopped
-    depends_on:
-      memshadow-db:
-        condition: service_healthy
-      memshadow-cache:
-        condition: service_healthy
-    environment:
-      # Database
-      POSTGRES_SERVER: memshadow-db
-      POSTGRES_USER: memshadow
-      POSTGRES_PASSWORD: ${MEMSHADOW_POSTGRES_PASSWORD:-1786}
-      POSTGRES_DB: memshadow
-      # Redis
-      REDIS_HOST: memshadow-cache
-      REDIS_PASSWORD: ${MEMSHADOW_REDIS_PASSWORD:-1786}
-      REDIS_URL: redis://:1786@memshadow-cache:6379/0
-      # Chroma
-      CHROMA_HOST: memshadow-vector
-      CHROMA_PORT: "8000"
-      # Features
-      ENABLE_SECURITY_MIDDLEWARE: "true"
-      WEB_ADMIN_PASSWORD: ${MEMSHADOW_ADMIN_PASSWORD:-1786}
-      EMBEDDING_DIMENSION: "4096"
-      # Safety: Explicitly disable blackbox mode
-      MEMSHADOW_BLACKBOX_MODE: "false"
-    networks:
-      - spectra-network
-
   # Qdrant Vector Database for Semantic Search (Enabled by default)
   qdrant:
     image: qdrant/qdrant:latest
@@ -188,12 +107,6 @@ volumes:
   spectra-checkpoints:
     driver: local
   spectra-config:
-    driver: local
-  memshadow-postgres-data:
-    driver: local
-  memshadow-redis-data:
-    driver: local
-  memshadow-chroma-data:
     driver: local
   caddy-data:
     driver: local

--- a/src/spectra_app/spectra_gui_launcher.py
+++ b/src/spectra_app/spectra_gui_launcher.py
@@ -782,16 +782,17 @@ class SpectraGUILauncher:
 
         @self.app.route('/api/sidecar/memshadow/status')
         def api_memshadow_status():
-            """Check the health and status of the MEMSHADOW sidecar."""
-            import requests
-            mem_url = os.getenv("SPECTRA_MEMSHADOW_URL", "http://memshadow:18080")
-            try:
-                res = requests.get(f"{mem_url}/health", timeout=2)
-                if res.status_code == 200:
-                    return jsonify({"active": True, "status": "Healthy", "url": "/memshadow"})
-                return jsonify({"active": False, "status": "Degraded", "error": f"HTTP {res.status_code}"})
-            except Exception as e:
-                return jsonify({"active": False, "status": "Unavailable", "error": str(e)})
+            """MEMSHADOW sidecar removed; retain integration contract for future reconnect."""
+            integration_url = os.getenv("SPECTRA_MEMSHADOW_URL", "").strip()
+            return jsonify(
+                {
+                    "active": False,
+                    "status": "Disabled",
+                    "integration_ready": True,
+                    "url": integration_url or None,
+                    "message": "MEMSHADOW sidecar is not deployed in this stack. Set SPECTRA_MEMSHADOW_URL to reconnect.",
+                }
+            )
 
         @self.app.route('/api/caas/process-queue', methods=['POST'])
         def api_caas_process_queue():
@@ -804,6 +805,109 @@ class SpectraGUILauncher:
                 
                 threading.Thread(target=_run, daemon=True).start()
                 return jsonify({"success": True, "message": "CaaS Queue processing initiated in background."})
+            except Exception as e:
+                return jsonify({"success": False, "error": str(e)}), 500
+
+        @self.app.route('/api/caas/flagged-channel', methods=['POST'])
+        def api_caas_flagged_channel():
+            """Flag or unflag a channel for guaranteed message logging."""
+            try:
+                from tgarchive.db import SpectraDB
+                from tgarchive.osint.caas.schema import ensure_schema, upsert_flagged_channel
+                data = request.get_json() or {}
+                channel_id = data.get("channel_id")
+                if channel_id is None:
+                    return jsonify({"success": False, "error": "channel_id is required"}), 400
+                reason = data.get("reason")
+                active = bool(data.get("active", True))
+
+                db = SpectraDB(Path(self.config.database_path))
+                ensure_schema(db)
+                upsert_flagged_channel(db, channel_id=int(channel_id), reason=reason, active=active)
+                return jsonify({"success": True, "channel_id": int(channel_id), "active": active})
+            except Exception as e:
+                return jsonify({"success": False, "error": str(e)}), 500
+
+        @self.app.route('/api/caas/invite-lists', methods=['POST'])
+        def api_caas_invite_lists():
+            """Add or update an invite list and attach channels for list-wide logging."""
+            try:
+                from tgarchive.db import SpectraDB
+                from tgarchive.osint.caas.schema import ensure_schema, add_or_update_invite_list
+                data = request.get_json() or {}
+                list_name = (data.get("list_name") or "").strip()
+                channels = data.get("channels") or []
+                if not list_name:
+                    return jsonify({"success": False, "error": "list_name is required"}), 400
+                if not isinstance(channels, list) or not channels:
+                    return jsonify({"success": False, "error": "channels must be a non-empty list"}), 400
+
+                normalized_channels = [int(c) for c in channels]
+                db = SpectraDB(Path(self.config.database_path))
+                ensure_schema(db)
+                list_id = add_or_update_invite_list(
+                    db,
+                    list_name=list_name,
+                    channels=normalized_channels,
+                    source_invite=data.get("source_invite"),
+                    reason=data.get("reason"),
+                    flagged=bool(data.get("flagged", False)),
+                )
+                return jsonify({"success": True, "list_id": list_id, "channel_count": len(normalized_channels)})
+            except Exception as e:
+                return jsonify({"success": False, "error": str(e)}), 500
+
+        @self.app.route('/api/caas/tracked-targets', methods=['GET', 'POST'])
+        def api_caas_tracked_targets():
+            """Track threat actors by username or channels by id for persistent logging."""
+            try:
+                from tgarchive.db import SpectraDB
+                from tgarchive.osint.caas.schema import ensure_schema, upsert_tracked_target
+                db = SpectraDB(Path(self.config.database_path))
+                ensure_schema(db)
+
+                if request.method == 'GET':
+                    rows = db.conn.execute(
+                        """
+                        SELECT id, target_type, actor_username, channel_id, reason, active, created_at, updated_at
+                        FROM caas_tracked_target
+                        ORDER BY updated_at DESC
+                        """
+                    ).fetchall()
+                    return jsonify(
+                        {
+                            "success": True,
+                            "targets": [
+                                {
+                                    "id": row[0],
+                                    "target_type": row[1],
+                                    "actor_username": row[2],
+                                    "channel_id": row[3],
+                                    "reason": row[4],
+                                    "active": bool(row[5]),
+                                    "created_at": row[6],
+                                    "updated_at": row[7],
+                                }
+                                for row in rows
+                            ],
+                        }
+                    )
+
+                data = request.get_json() or {}
+                target_type = (data.get("target_type") or "").strip()
+                reason = data.get("reason")
+                active = bool(data.get("active", True))
+                target_id = upsert_tracked_target(
+                    db,
+                    target_type=target_type,
+                    actor_username=data.get("actor_username"),
+                    channel_id=data.get("channel_id"),
+                    reason=reason,
+                    active=active,
+                )
+                return jsonify({"success": True, "id": target_id, "target_type": target_type, "active": active})
+            except ValueError as exc:
+                return jsonify({"success": False, "error": str(exc)}), 400
             except Exception as e:
                 return jsonify({"success": False, "error": str(e)}), 500
 

--- a/templates/unified_dashboard.html
+++ b/templates/unified_dashboard.html
@@ -115,7 +115,7 @@
                     <div style="margin-top: 20px; display: flex; gap: 10px;">
                         <div class="status-pill">AGENTS: {{ system_status.total_agents }}</div>
                         <div class="status-pill">HOST: {{ access_host }}</div>
-                        <div class="status-pill" id="memshadow-pill" style="display:none; border-color: var(--accent); color: var(--accent);">MEMSHADOW: ACTIVE</div>
+                        <div class="status-pill" id="memshadow-pill" style="display:none; border-color: var(--accent); color: var(--accent);">MEMSHADOW: INTEGRATION READY</div>
                     </div>
                 </section>
 
@@ -241,10 +241,17 @@
                 const res = await fetch('/api/sidecar/memshadow/status');
                 const data = await res.json();
                 const pill = document.getElementById('memshadow-pill');
-                if (data.active) {
+                if (data.active || data.integration_ready) {
                     pill.style.display = 'block';
-                    pill.onclick = () => window.location.href = data.url;
-                    pill.style.cursor = 'pointer';
+                    if (data.active) {
+                        pill.textContent = 'MEMSHADOW: ACTIVE';
+                        pill.onclick = () => window.location.href = data.url;
+                        pill.style.cursor = 'pointer';
+                    } else {
+                        pill.textContent = 'MEMSHADOW: INTEGRATION READY';
+                        pill.onclick = null;
+                        pill.style.cursor = 'default';
+                    }
                 } else {
                     pill.style.display = 'none';
                 }

--- a/tgarchive/osint/caas/queue_worker.py
+++ b/tgarchive/osint/caas/queue_worker.py
@@ -9,6 +9,84 @@ from tgarchive.osint.caas.schema import ensure_schema
 
 logger = logging.getLogger(__name__)
 
+def _log_flagged_message(
+    db: SpectraDB,
+    channel_id: int,
+    message_id: int,
+    content: str,
+    sender_username: str | None = None,
+) -> None:
+    rows = db.conn.execute(
+        "SELECT reason FROM caas_flagged_channel WHERE channel_id = ? AND active = 1",
+        (channel_id,),
+    ).fetchall()
+    for (reason,) in rows:
+        db.conn.execute(
+            """
+            INSERT OR IGNORE INTO caas_flagged_message_log
+            (created_at, channel_id, message_id, list_id, list_name, trigger_type, reason, content)
+            VALUES (datetime('now'), ?, ?, NULL, NULL, 'channel', ?, ?)
+            """,
+            (channel_id, message_id, reason, content),
+        )
+
+    list_rows = db.conn.execute(
+        """
+        SELECT il.id, il.list_name, il.reason
+        FROM caas_invite_list il
+        JOIN caas_invite_list_channel ilc ON il.id = ilc.list_id
+        WHERE ilc.channel_id = ? AND il.flagged = 1
+        """,
+        (channel_id,),
+    ).fetchall()
+    for list_id, list_name, reason in list_rows:
+        db.conn.execute(
+            """
+            INSERT OR IGNORE INTO caas_flagged_message_log
+            (created_at, channel_id, message_id, list_id, list_name, trigger_type, reason, content)
+            VALUES (datetime('now'), ?, ?, ?, ?, 'invite_list', ?, ?)
+            """,
+            (channel_id, message_id, list_id, list_name, reason, content),
+        )
+
+    channel_tracking_rows = db.conn.execute(
+        """
+        SELECT reason
+        FROM caas_tracked_target
+        WHERE target_type = 'channel_id' AND channel_id = ? AND active = 1
+        """,
+        (channel_id,),
+    ).fetchall()
+    for (reason,) in channel_tracking_rows:
+        db.conn.execute(
+            """
+            INSERT OR IGNORE INTO caas_flagged_message_log
+            (created_at, channel_id, message_id, list_id, list_name, trigger_type, reason, content)
+            VALUES (datetime('now'), ?, ?, NULL, NULL, 'tracked_channel', ?, ?)
+            """,
+            (channel_id, message_id, reason, content),
+        )
+
+    if sender_username:
+        normalized_username = sender_username.strip().lstrip("@").lower()
+        actor_tracking_rows = db.conn.execute(
+            """
+            SELECT reason
+            FROM caas_tracked_target
+            WHERE target_type = 'actor_username' AND actor_username = ? AND active = 1
+            """,
+            (normalized_username,),
+        ).fetchall()
+        for (reason,) in actor_tracking_rows:
+            db.conn.execute(
+                """
+                INSERT OR IGNORE INTO caas_flagged_message_log
+                (created_at, channel_id, message_id, list_id, list_name, trigger_type, reason, content)
+                VALUES (datetime('now'), ?, ?, NULL, ?, 'tracked_actor', ?, ?)
+                """,
+                (channel_id, message_id, f"@{normalized_username}", reason, content),
+            )
+
 
 def _claim_batch(db: SpectraDB, batch_size: int) -> list[tuple]:
     rows = db.conn.execute(
@@ -51,6 +129,7 @@ def process_queue(db_path: str | Path = "spectra.db", batch_size: int = 500, onc
         for row in rows:
             q_id, channel_id, message_id, topic_id, sender_id, sender_username, date_value, content = row
             try:
+                _log_flagged_message(db, channel_id, message_id, content or "", sender_username=sender_username)
                 profile = profiler.profile_message(content or "", sender_username=sender_username)
                 profiler.save_profile(db, channel_id, message_id, profile)
                 db.conn.execute(

--- a/tgarchive/osint/caas/schema.py
+++ b/tgarchive/osint/caas/schema.py
@@ -81,6 +81,69 @@ CREATE TABLE IF NOT EXISTS caas_alert (
     evidence_json TEXT,
     status TEXT NOT NULL DEFAULT 'new'
 );
+
+CREATE TABLE IF NOT EXISTS caas_flagged_channel (
+    channel_id INTEGER PRIMARY KEY,
+    reason TEXT,
+    created_at TEXT NOT NULL,
+    active INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE TABLE IF NOT EXISTS caas_invite_list (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    list_name TEXT NOT NULL UNIQUE,
+    source_invite TEXT,
+    reason TEXT,
+    flagged INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS caas_invite_list_channel (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    list_id INTEGER NOT NULL REFERENCES caas_invite_list(id) ON DELETE CASCADE,
+    channel_id INTEGER NOT NULL,
+    channel_ref TEXT,
+    created_at TEXT NOT NULL,
+    UNIQUE(list_id, channel_id)
+);
+CREATE INDEX IF NOT EXISTS idx_caas_invite_list_channel_id ON caas_invite_list_channel(channel_id);
+
+CREATE TABLE IF NOT EXISTS caas_flagged_message_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    created_at TEXT NOT NULL,
+    channel_id INTEGER NOT NULL,
+    message_id INTEGER NOT NULL,
+    list_id INTEGER REFERENCES caas_invite_list(id),
+    list_name TEXT,
+    trigger_type TEXT NOT NULL,
+    reason TEXT,
+    content TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_caas_flagged_message_log_channel_id ON caas_flagged_message_log(channel_id);
+CREATE INDEX IF NOT EXISTS idx_caas_flagged_message_log_message_id ON caas_flagged_message_log(message_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_caas_flagged_message_log_dedupe
+ON caas_flagged_message_log(channel_id, message_id, trigger_type, ifnull(list_id, -1));
+
+CREATE TABLE IF NOT EXISTS caas_tracked_target (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    target_type TEXT NOT NULL CHECK(target_type IN ('actor_username', 'channel_id')),
+    actor_username TEXT,
+    channel_id INTEGER,
+    reason TEXT,
+    active INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    CHECK(
+        (target_type = 'actor_username' AND actor_username IS NOT NULL AND channel_id IS NULL)
+        OR
+        (target_type = 'channel_id' AND channel_id IS NOT NULL AND actor_username IS NULL)
+    )
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_caas_tracked_target_actor
+ON caas_tracked_target(target_type, actor_username);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_caas_tracked_target_channel
+ON caas_tracked_target(target_type, channel_id);
 """
 
 
@@ -140,3 +203,120 @@ def upsert_channel_profile(db: Any, *, channel_id: int, channel_link: Optional[s
         ),
     )
     db.conn.commit()
+
+
+def upsert_flagged_channel(db: Any, *, channel_id: int, reason: Optional[str] = None, active: bool = True) -> None:
+    ensure_schema(db)
+    now = datetime.utcnow().isoformat()
+    db.conn.execute(
+        """
+        INSERT INTO caas_flagged_channel(channel_id, reason, created_at, active)
+        VALUES (?, ?, ?, ?)
+        ON CONFLICT(channel_id) DO UPDATE SET
+            reason=excluded.reason,
+            active=excluded.active
+        """,
+        (channel_id, reason, now, 1 if active else 0),
+    )
+    db.conn.commit()
+
+
+def add_or_update_invite_list(
+    db: Any,
+    *,
+    list_name: str,
+    channels: list[int],
+    source_invite: Optional[str] = None,
+    reason: Optional[str] = None,
+    flagged: bool = False,
+) -> int:
+    ensure_schema(db)
+    now = datetime.utcnow().isoformat()
+    db.conn.execute(
+        """
+        INSERT INTO caas_invite_list(list_name, source_invite, reason, flagged, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(list_name) DO UPDATE SET
+            source_invite=excluded.source_invite,
+            reason=excluded.reason,
+            flagged=excluded.flagged,
+            updated_at=excluded.updated_at
+        """,
+        (list_name, source_invite, reason, 1 if flagged else 0, now, now),
+    )
+    row = db.conn.execute("SELECT id FROM caas_invite_list WHERE list_name = ?", (list_name,)).fetchone()
+    if not row:
+        raise RuntimeError(f"Failed to load invite list id for {list_name}")
+    list_id = int(row[0])
+
+    for channel_id in channels:
+        db.conn.execute(
+            """
+            INSERT INTO caas_invite_list_channel(list_id, channel_id, channel_ref, created_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(list_id, channel_id) DO UPDATE SET
+                channel_ref=excluded.channel_ref
+            """,
+            (list_id, int(channel_id), str(channel_id), now),
+        )
+
+    db.conn.commit()
+    return list_id
+
+
+def upsert_tracked_target(
+    db: Any,
+    *,
+    target_type: str,
+    actor_username: Optional[str] = None,
+    channel_id: Optional[int] = None,
+    reason: Optional[str] = None,
+    active: bool = True,
+) -> int:
+    ensure_schema(db)
+    if target_type not in {"actor_username", "channel_id"}:
+        raise ValueError("target_type must be one of: actor_username, channel_id")
+
+    now = datetime.utcnow().isoformat()
+    if target_type == "actor_username":
+        if not actor_username:
+            raise ValueError("actor_username is required for actor_username tracking")
+        normalized_username = actor_username.strip().lstrip("@").lower()
+        db.conn.execute(
+            """
+            INSERT INTO caas_tracked_target(target_type, actor_username, channel_id, reason, active, created_at, updated_at)
+            VALUES (?, ?, NULL, ?, ?, ?, ?)
+            ON CONFLICT(target_type, actor_username) DO UPDATE SET
+                reason=excluded.reason,
+                active=excluded.active,
+                updated_at=excluded.updated_at
+            """,
+            (target_type, normalized_username, reason, 1 if active else 0, now, now),
+        )
+        row = db.conn.execute(
+            "SELECT id FROM caas_tracked_target WHERE target_type = ? AND actor_username = ?",
+            (target_type, normalized_username),
+        ).fetchone()
+    else:
+        if channel_id is None:
+            raise ValueError("channel_id is required for channel_id tracking")
+        db.conn.execute(
+            """
+            INSERT INTO caas_tracked_target(target_type, actor_username, channel_id, reason, active, created_at, updated_at)
+            VALUES (?, NULL, ?, ?, ?, ?, ?)
+            ON CONFLICT(target_type, channel_id) DO UPDATE SET
+                reason=excluded.reason,
+                active=excluded.active,
+                updated_at=excluded.updated_at
+            """,
+            (target_type, int(channel_id), reason, 1 if active else 0, now, now),
+        )
+        row = db.conn.execute(
+            "SELECT id FROM caas_tracked_target WHERE target_type = ? AND channel_id = ?",
+            (target_type, int(channel_id)),
+        ).fetchone()
+
+    if not row:
+        raise RuntimeError("Failed to resolve tracked target id")
+    db.conn.commit()
+    return int(row[0])

--- a/tgarchive/tests/test_caas_flagged_logging.py
+++ b/tgarchive/tests/test_caas_flagged_logging.py
@@ -1,0 +1,127 @@
+from pathlib import Path
+
+from tgarchive.db import SpectraDB
+from tgarchive.osint.caas.queue_worker import process_queue
+from tgarchive.osint.caas.schema import (
+    add_or_update_invite_list,
+    ensure_schema,
+    enqueue_profile_candidate,
+    upsert_tracked_target,
+    upsert_flagged_channel,
+)
+
+
+def _count(db: SpectraDB, sql: str, params=()):
+    row = db.conn.execute(sql, params).fetchone()
+    return int(row[0]) if row and row[0] is not None else 0
+
+
+def test_flagged_channel_logs_messages(tmp_path: Path):
+    db_path = tmp_path / "caas.db"
+    db = SpectraDB(db_path)
+    ensure_schema(db)
+
+    upsert_flagged_channel(db, channel_id=1001, reason="manual review", active=True)
+    enqueue_profile_candidate(
+        db,
+        channel_id=1001,
+        message_id=501,
+        topic_id=None,
+        sender_id=42,
+        sender_username="tester",
+        date="2026-01-01T00:00:00",
+        content="Need fresh logs 500 usd",
+    )
+
+    processed = process_queue(db_path=db_path, batch_size=100, once=True)
+    assert processed == 1
+
+    assert _count(db, "SELECT COUNT(*) FROM caas_flagged_message_log") == 1
+    assert _count(db, "SELECT COUNT(*) FROM caas_flagged_message_log WHERE trigger_type='channel'") == 1
+
+
+def test_flagged_invite_list_logs_messages(tmp_path: Path):
+    db_path = tmp_path / "caas.db"
+    db = SpectraDB(db_path)
+    ensure_schema(db)
+
+    add_or_update_invite_list(
+        db,
+        list_name="incident-alpha",
+        channels=[2001, 2002],
+        source_invite="https://t.me/+example",
+        reason="list-wide surveillance",
+        flagged=True,
+    )
+    enqueue_profile_candidate(
+        db,
+        channel_id=2002,
+        message_id=777,
+        topic_id=None,
+        sender_id=88,
+        sender_username="source",
+        date="2026-01-01T00:00:00",
+        content="panel access monthly $250",
+    )
+
+    processed = process_queue(db_path=db_path, batch_size=100, once=True)
+    assert processed == 1
+
+    assert _count(db, "SELECT COUNT(*) FROM caas_flagged_message_log") == 1
+    assert _count(db, "SELECT COUNT(*) FROM caas_flagged_message_log WHERE trigger_type='invite_list'") == 1
+
+
+def test_tracked_channel_logs_messages(tmp_path: Path):
+    db_path = tmp_path / "caas.db"
+    db = SpectraDB(db_path)
+    ensure_schema(db)
+
+    upsert_tracked_target(
+        db,
+        target_type="channel_id",
+        channel_id=3001,
+        reason="watch channel 3001",
+        active=True,
+    )
+    enqueue_profile_candidate(
+        db,
+        channel_id=3001,
+        message_id=1001,
+        topic_id=None,
+        sender_id=1,
+        sender_username="sender",
+        date="2026-01-01T00:00:00",
+        content="hello from tracked channel",
+    )
+
+    processed = process_queue(db_path=db_path, batch_size=100, once=True)
+    assert processed == 1
+    assert _count(db, "SELECT COUNT(*) FROM caas_flagged_message_log WHERE trigger_type='tracked_channel'") == 1
+
+
+def test_tracked_actor_username_logs_messages(tmp_path: Path):
+    db_path = tmp_path / "caas.db"
+    db = SpectraDB(db_path)
+    ensure_schema(db)
+
+    upsert_tracked_target(
+        db,
+        target_type="actor_username",
+        actor_username="@target_actor",
+        reason="watch actor",
+        active=True,
+    )
+    enqueue_profile_candidate(
+        db,
+        channel_id=4001,
+        message_id=1002,
+        topic_id=None,
+        sender_id=2,
+        sender_username="target_actor",
+        date="2026-01-01T00:00:00",
+        content="actor message",
+    )
+
+    processed = process_queue(db_path=db_path, batch_size=100, once=True)
+    assert processed == 1
+    assert _count(db, "SELECT COUNT(*) FROM caas_flagged_message_log WHERE trigger_type='tracked_actor'") == 1


### PR DESCRIPTION
### Motivation

- Introduce persistent flagged-message logging, tracking, and invite-list support to ensure important messages are captured for audit and analysis.
- Surface CAAS management operations via the web console API so operators can flag channels, manage invite-lists, and maintain tracked targets from the UI.
- Simplify the default Docker stack by removing the MEMSHADOW sidecar while retaining a reconnection contract and making integration optional.

### Description

- Added new CAAS database tables and indexes in `tgarchive/osint/caas/schema.py` including `caas_flagged_channel`, `caas_invite_list`, `caas_invite_list_channel`, `caas_flagged_message_log`, and `caas_tracked_target`, plus helper functions `upsert_flagged_channel`, `add_or_update_invite_list`, and `upsert_tracked_target` to manage them.
- Implemented `_log_flagged_message` in `tgarchive/osint/caas/queue_worker.py` and wired it into `process_queue` to record flagged messages for channels, invite-lists, tracked channels, and tracked actor usernames before profiling.
- Added CAAS control endpoints in `src/spectra_app/spectra_gui_launcher.py`: `api_caas/flagged-channel`, `api_caas/invite-lists`, and `api_caas/tracked-targets`, and modified the MEMSHADOW status endpoint to report `integration_ready` with guidance to set `SPECTRA_MEMSHADOW_URL`.
- Updated dashboard UI `templates/unified_dashboard.html` to display an "INTEGRATION READY" MEMSHADOW pill when sidecar is not deployed and improved pill behavior.
- Removed MEMSHADOW services and volumes from `docker-compose.yml`, added `SPECTRA_MEMSHADOW_URL` environment passthrough to the `spectra` service, and removed the MEMSHADOW route from `Caddyfile` to make the sidecar optional by default.
- Added `.env.example` documenting key environment variables and provider keys.
- Added unit tests `tgarchive/tests/test_caas_flagged_logging.py` covering flagged channel, invite-list, tracked channel, and tracked actor logging flows.

### Testing

- Ran the new unit tests with `pytest tgarchive/tests/test_caas_flagged_logging.py` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c863bf8c8325b8bf512f277d353e)